### PR TITLE
Use Sketch template names for watchOS icons

### DIFF
--- a/Sources/SashaCore/Models/IconFactory.swift
+++ b/Sources/SashaCore/Models/IconFactory.swift
@@ -98,10 +98,10 @@ final class IconFactory {
                     Icon(idiom: idiom,size: 512, filename: name, scale: 1),
                     Icon(idiom: idiom,size: 512, filename: name, scale: 2)]
         case .watch:
-            return [Icon(idiom: idiom,size: 24, filename: name, scale: 2, role: .notificationCenter, subtype: .mm38),
+            return [Icon(idiom: idiom, size: 24, filename: name, scale: 2, role: .notificationCenter, subtype: .mm38),
                     Icon(idiom: idiom, size: 27.5, filename: name, scale: 2, role: .notificationCenter, subtype: .mm42),
-                    Icon(idiom: idiom,size: 29, filename: name, scale: 2, role: .companionSettings),
-                    Icon(idiom: idiom, size: 29, filename: name, scale: 3, role: .companionSettings),
+                    Icon(idiom: idiom, size: 29, filename: name + "-Companion", scale: 2, role: .companionSettings),
+                    Icon(idiom: idiom, size: 29, filename: name + "-Companion", scale: 3, role: .companionSettings),
                     Icon(idiom: idiom, size: 40, filename: name, scale: 2, role: .appLauncher, subtype: .mm38),
                     Icon(idiom: idiom, size: 44, filename: name, scale: 2, role: .appLauncher, subtype: .mm40),
                     Icon(idiom: idiom, size: 50, filename: name, scale: 2, role: .appLauncher, subtype: .mm44),
@@ -109,7 +109,7 @@ final class IconFactory {
                     Icon(idiom: idiom, size: 98, filename: name, scale: 2, role: .quickLook, subtype: .mm42),
                     Icon(idiom: idiom, size: 108, filename: name, scale: 2, role: .quickLook, subtype: .mm44)]
         case .watchMarketing:
-            return [Icon(idiom: idiom, size: 1024, filename: name, scale: 1)]
+            return [Icon(idiom: idiom, size: 1024, filename: name + "-AppStore", scale: 1)]
         case .complicationCircular:
             return [Icon(idiom: idiom, size: 16, filename: name + "-\(Icon.Subtype.mm38.rawValue)", screenWidth: "<=145", scale: 2),
                     Icon(idiom: idiom, size: 18, filename: name + "-\(Icon.Subtype.mm42.rawValue)", screenWidth: ">161", scale: 2),

--- a/Sources/SashaCore/Services/IconService.swift
+++ b/Sources/SashaCore/Services/IconService.swift
@@ -19,6 +19,7 @@ final class IconService {
         static let height = "PixelHeight"
         static let lanczosFilterName = "CILanczosScaleTransform"
         static let iconName = "Icon-App"
+        static let watchOSIconName = "Icon-AppleWatch"
         static let complicationName = "Complication"
         static let iconSetName = "AppIcon.appiconset"
         static let complicationSetName = "Complication.complicationset"
@@ -50,7 +51,7 @@ final class IconService {
         if let idioms = idioms {
             fullIdioms.append(contentsOf: idioms)
         }
-        try generateIcons(for: imageURL, idioms: fullIdioms, output: output)
+        try generateIcons(withIconName: Keys.iconName, for: imageURL, idioms: fullIdioms, output: output)
     }
 
     /// Generates icons for macOS platform.
@@ -59,7 +60,7 @@ final class IconService {
     /// - Parameter output: Output path for generated icons. Default value is nil.
     /// - Throws: `IconService.Error` errors.
     func generateMacOSIcons(for imageURL: URL, output: String? = nil) throws {
-        try generateIcons(for: imageURL, idioms: [.mac], output: output)
+        try generateIcons(withIconName: Keys.iconName, for: imageURL, idioms: [.mac], output: output)
     }
 
     /// Generates icons for watchOS platform.
@@ -68,7 +69,10 @@ final class IconService {
     /// - Parameter output: Output path for generated icons. Default value is nil.
     /// - Throws: `IconService.Error` errors.
     func generateWatchOSIcons(for imageURL: URL, output: String? = nil) throws {
-        try generateIcons(for: imageURL, idioms: [.watch, .watchMarketing], output: output)
+        try generateIcons(withIconName: Keys.watchOSIconName,
+                          for: imageURL,
+                          idioms: [.watch, .watchMarketing],
+                          output: output)
     }
 
     /// Generates icons for watchOS platform.
@@ -150,13 +154,17 @@ final class IconService {
 
     /// Generates icons for Apple platforms.
     ///
+    /// - Parameter iconName: The name of generated icons.
     /// - Parameter imageURL: The url for original image.
     /// - Parameter idioms: Idioms for icons.
     /// - Parameter output: Output path for generated icons. Default value is nil.
     /// - Throws: `IconService.Error` errors.
-    private func generateIcons(for imageURL: URL, idioms: [Icon.Idiom], output: String? = nil) throws {
+    private func generateIcons(withIconName iconName: String,
+                               for imageURL: URL,
+                               idioms: [Icon.Idiom],
+                               output: String? = nil) throws {
         let image = try self.image(for: imageURL)
-        let iconSet = iconFactory.makeSet(withName: Keys.iconName,
+        let iconSet = iconFactory.makeSet(withName: iconName,
                                           idioms: idioms)
         var folderName = Keys.iconSetName
         if let output = output {


### PR DESCRIPTION
Closes #13.

Hi @artemnovichkov, I’ve updated the Apple Watch icon names. Now Sasha generates the following icons:

```
Icon-AppleWatch-24x24@2x.png
Icon-AppleWatch-27.5x27.5@2x.png
Icon-AppleWatch-40x40@2x.png
Icon-AppleWatch-44x44@2x.png
Icon-AppleWatch-50x50@2x.png
Icon-AppleWatch-86x86@2x.png
Icon-AppleWatch-98x98@2x.png
Icon-AppleWatch-108x108@2x.png
Icon-AppleWatch-AppStore-1024x1024@1x.png
Icon-AppleWatch-Companion-29x29@2x.png
Icon-AppleWatch-Companion-29x29@3x.png
```

Most of these icons now match the filenames mentioned in #13:

![Sketch template icon names](https://user-images.githubusercontent.com/5051597/45795757-14e30d80-bcbf-11e8-8d77-03b9504de42d.png)

though there are a few icons that Sasha generates, but the image in #13 doesn’t show:

```
Icon-AppleWatch-50x50@2x.png
Icon-AppleWatch-108x108@2x.png
```

and there’s a few icons that the image in #13 shows, but Sasha still doesn’t generate:

```
Icon-AppleWatch-100x100@2x.png
Icon-AppleWatch-216x216@2x.png
```

How should I resolve these discrepancies? It looks like 50x50@2x and 108x108@2x are both for the new 44 mm watch, so the Sketch template might just be out of date.

What about 100x100@2x and 216x216@2x? What `role` and `subtype` should those be set as in `IconFactory.swift`?