### PR TITLE
Fixes #10: Change icons alpha to 1

### DIFF
--- a/Sources/SashaCore/Services/IconService.swift
+++ b/Sources/SashaCore/Services/IconService.swift
@@ -4,6 +4,7 @@
 
 import CoreImage
 import Files
+import AppKit
 
 final class IconService {
 
@@ -135,6 +136,9 @@ final class IconService {
     // MARK: - Private
 
     private func image(for imageURL: URL) throws -> CIImage {
+        if let rep = NSImageRep(contentsOf: imageURL), !rep.isOpaque {
+            print("\u{001B}[0;33mImage has transparency... filling regions...\u{001B}[0;0m")
+        }
         guard let image = CIImage(contentsOf: imageURL) else {
             throw Error.imageCreationFailed
         }

--- a/Sources/SashaCore/Services/IconService.swift
+++ b/Sources/SashaCore/Services/IconService.swift
@@ -202,6 +202,7 @@ final class IconService {
     ///   - folderName: The name of folder for generated icons.
     /// - Throws: `IconService.Error` errors.
     private func generateIcons(from image: CIImage, icons: [IconRepresentable], folderName: String) throws {
+        let image = image.settingAlphaOne(in: image.extent)
         let filter = CIFilter(name: Keys.lanczosFilterName)!
         filter.setValue(image, forKey: kCIInputImageKey)
         filter.setValue(1, forKey: kCIInputAspectRatioKey)


### PR DESCRIPTION
Uploading Icons generated from images with transparency in iTunes Connect should now work.