### PR TITLE
Fixes #9: Add different sizes for different platforms

### DIFF
--- a/Sources/SashaCore/Services/IconService.swift
+++ b/Sources/SashaCore/Services/IconService.swift
@@ -81,6 +81,7 @@ final class IconService {
     /// - Parameter output: Output path for generated icons. Default value is nil.
     /// - Throws: `IconService.Error` errors.
     func generateWatchOSComplicationIcons(for imageURL: URL, output: String? = nil) throws {
+        let image = try self.image(for: imageURL)
         let idioms: [Icon.Idiom] = [.complicationCircular,
                                     .complicationExtraLarge,
                                     .complicationGraphicBezel,
@@ -93,12 +94,6 @@ final class IconService {
         if let output = output {
             folderName = output + folderName
         }
-        for idiom in idioms {
-            let iconSet = iconFactory.makeSet(withName: Keys.complicationName,
-                                              idioms: [idiom])
-            Keys.defaultSize = max(Keys.defaultSize, maxSize(for: iconSet))
-        }
-        let image = try self.image(for: imageURL)
         for idiom in idioms {
             let iconSet = iconFactory.makeSet(withName: Keys.complicationName,
                                               idioms: [idiom])
@@ -169,8 +164,6 @@ final class IconService {
         let image = try self.image(for: imageURL)
         let iconSet = iconFactory.makeSet(withName: iconName,
                                           idioms: idioms)
-        Keys.defaultSize = maxSize(for: iconSet)
-        let image = try self.image(for: imageURL)
         var folderName = Keys.iconSetName
         if let output = output {
             folderName = output + folderName
@@ -251,14 +244,14 @@ final class IconService {
                 throw Error.sizeReadingFailed
         }
 
-        //check for non-square image (needs to be adapted later for non-square Apple TV icons)
-        guard width == height else {
-            throw Error.wrongSizeDetected
-        }
-
         //check for smaller image than necessary
         guard width >= icon.iconSize, height >= icon.iconSize else {
-            throw Error.wrongSizeDetected
+            throw Error.wrongSizeDetected(actualWidth: width, actualHeight: height, expectedWidth: icon.iconSize, expectedHeight: icon.iconSize)
+        }
+        
+        //check for non-square image (needs to be adapted later for non-square Apple TV icons)
+        guard width == height else {
+            throw Error.wrongSizeDetected(actualWidth: width, actualHeight: height, expectedWidth: icon.iconSize, expectedHeight: icon.iconSize)
         }
 
         return icon.iconSize / width

--- a/Sources/SashaCore/Services/IconService.swift
+++ b/Sources/SashaCore/Services/IconService.swift
@@ -246,12 +246,14 @@ final class IconService {
 
         //check for smaller image than necessary
         guard width >= icon.iconSize, height >= icon.iconSize else {
-            throw Error.wrongSizeDetected(actualWidth: width, actualHeight: height, expectedWidth: icon.iconSize, expectedHeight: icon.iconSize)
+            throw Error.wrongSizeDetected(actualWidth: width, actualHeight: height,
+                                          expectedWidth: icon.iconSize, expectedHeight: icon.iconSize)
         }
         
         //check for non-square image (needs to be adapted later for non-square Apple TV icons)
         guard width == height else {
-            throw Error.wrongSizeDetected(actualWidth: width, actualHeight: height, expectedWidth: icon.iconSize, expectedHeight: icon.iconSize)
+            throw Error.wrongSizeDetected(actualWidth: width, actualHeight: height,
+                                          expectedWidth: icon.iconSize, expectedHeight: icon.iconSize)
         }
 
         return icon.iconSize / width

--- a/Sources/SashaCore/Services/IconService.swift
+++ b/Sources/SashaCore/Services/IconService.swift
@@ -24,7 +24,7 @@ final class IconService {
         static let complicationSetName = "Complication.complicationset"
         static let contentsName = "Contents.json"
         static let androidIconFolder = "Android"
-        static let defaultSize: Float = 1024
+        static var defaultSize: Float = 0
     }
 
     private let iconFactory: IconFactory
@@ -77,7 +77,6 @@ final class IconService {
     /// - Parameter output: Output path for generated icons. Default value is nil.
     /// - Throws: `IconService.Error` errors.
     func generateWatchOSComplicationIcons(for imageURL: URL, output: String? = nil) throws {
-        let image = try self.image(for: imageURL)
         let idioms: [Icon.Idiom] = [.complicationCircular,
                                     .complicationExtraLarge,
                                     .complicationGraphicBezel,
@@ -90,6 +89,12 @@ final class IconService {
         if let output = output {
             folderName = output + folderName
         }
+        for idiom in idioms {
+            let iconSet = iconFactory.makeSet(withName: Keys.complicationName,
+                                              idioms: [idiom])
+            Keys.defaultSize = max(Keys.defaultSize, maxSize(for: iconSet))
+        }
+        let image = try self.image(for: imageURL)
         for idiom in idioms {
             let iconSet = iconFactory.makeSet(withName: Keys.complicationName,
                                               idioms: [idiom])
@@ -106,13 +111,15 @@ final class IconService {
     /// - Parameter output: Output path for generated icons. Default value is nil.
     /// - Throws: `IconService.Error` errors.
     func generateAndroidIcons(for imageURL: URL, output: String? = nil) throws {
-        let image = try self.image(for: imageURL)
         var folderName = Keys.androidIconFolder
         if let output = output {
             folderName = output + folderName
         }
+        let icons = iconFactory.makeAndroidIcons()
+        Keys.defaultSize = maxSize(for: icons)
+        let image = try self.image(for: imageURL)
         try generateIcons(from: image,
-                          icons: iconFactory.makeAndroidIcons(),
+                          icons: icons,
                           folderName: folderName)
     }
 
@@ -122,13 +129,15 @@ final class IconService {
     /// - Parameter output: Output path for generated icons. Default value is nil.
     /// - Throws: `IconService.Error` errors.
     func generateAndroidWearIcons(for imageURL: URL, output: String? = nil) throws {
-        let image = try self.image(for: imageURL)
         var folderName = Keys.androidIconFolder
         if let output = output {
             folderName = output + folderName
         }
+        let icons = iconFactory.makeAndroidWearIcons()
+        Keys.defaultSize = maxSize(for: icons)
+        let image = try self.image(for: imageURL)
         try generateIcons(from: image,
-                          icons: iconFactory.makeAndroidWearIcons(),
+                          icons: icons,
                           folderName: folderName)
     }
 
@@ -142,10 +151,20 @@ final class IconService {
             let height = image.properties[Keys.height] as? Float else {
                 throw Error.sizeReadingFailed
         }
-        guard width == Keys.defaultSize, height == Keys.defaultSize else {
+        guard width >= Keys.defaultSize, height >= Keys.defaultSize else {
             throw Error.wrongSizeDetected
         }
         return image
+    }
+
+    func maxSize(for iconSet: AppIconSet) -> Float {
+        let max = iconSet.icons.map { $0.size * $0.scale }.max()
+        return max ?? 0
+    }
+
+    func maxSize(for iconSet: [AndroidIcon]) -> Float {
+        let max = iconSet.map { $0.size }.max()
+        return max ?? 0
     }
 
     /// Generates icons for Apple platforms.
@@ -155,9 +174,10 @@ final class IconService {
     /// - Parameter output: Output path for generated icons. Default value is nil.
     /// - Throws: `IconService.Error` errors.
     private func generateIcons(for imageURL: URL, idioms: [Icon.Idiom], output: String? = nil) throws {
-        let image = try self.image(for: imageURL)
         let iconSet = iconFactory.makeSet(withName: Keys.iconName,
                                           idioms: idioms)
+        Keys.defaultSize = maxSize(for: iconSet)
+        let image = try self.image(for: imageURL)
         var folderName = Keys.iconSetName
         if let output = output {
             folderName = output + folderName

--- a/Sources/SashaCore/Services/IconService.swift
+++ b/Sources/SashaCore/Services/IconService.swift
@@ -238,7 +238,7 @@ final class IconService {
             try file.write(data: outputData)
         }
     }
-    
+
     /// Checks icon and image size compatibility and returns the scale factor between them
     ///
     /// - Parameters:
@@ -250,17 +250,17 @@ final class IconService {
             let height = image.properties[Keys.height] as? Float else {
                 throw Error.sizeReadingFailed
         }
-        
+
         //check for non-square image (needs to be adapted later for non-square Apple TV icons)
         guard width == height else {
             throw Error.wrongSizeDetected
         }
-        
+
         //check for smaller image than necessary
         guard width >= icon.iconSize, height >= icon.iconSize else {
             throw Error.wrongSizeDetected
         }
-        
+
         return icon.iconSize / width
     }
 }

--- a/Sources/SashaCore/Services/IconService.swift
+++ b/Sources/SashaCore/Services/IconService.swift
@@ -249,7 +249,7 @@ final class IconService {
             throw Error.wrongSizeDetected(actualWidth: width, actualHeight: height,
                                           expectedWidth: icon.iconSize, expectedHeight: icon.iconSize)
         }
-        
+
         //check for non-square image (needs to be adapted later for non-square Apple TV icons)
         guard width == height else {
             throw Error.wrongSizeDetected(actualWidth: width, actualHeight: height,


### PR DESCRIPTION
These changes calculate the maximum pixel size for each platform and use that to determine the Keys.defaultSize property. So far the only difference is that if the user wants to use a smaller image to generate say a set of complication images, he can. It would be nice to also add a query where the user could check the max sizes per platform without having to necessarily generate images.